### PR TITLE
add shortcode.has()

### DIFF
--- a/lib/shortcode-parser.js
+++ b/lib/shortcode-parser.js
@@ -99,6 +99,10 @@ module.exports = {
     delete shortcodes[name];
   },
   
+  has: function(name){
+    return !!shortcodes[name];
+  },
+
   parse: function(buf, extra, context) {
     
     context = context || shortcodes;

--- a/test/unit.js
+++ b/test/unit.js
@@ -85,6 +85,10 @@ vows.describe("Shortcode Parser").addBatch({
       assert.deepEqual(val, shortcode._shortcodes);
     },
     
+    "Has shortcode handlers": function(val){
+      for (var k in val) assert(shortcode.has(k));
+    },
+
     "Removes shortcode handlers": function(val) {
       var noop = function() {};
       shortcode.add('test', noop);


### PR DESCRIPTION
Hi, thanks for your library. I made use of it in [metalsmith-shortcodes](https://github.com/ericgj/metalsmith-shortcodes).  I've added this simple `has()` method to hide the _shortcodes private variable. 
